### PR TITLE
fix flat config support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: Test
+
+on:
+  pull_request_target:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+
+      - name: Set node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
+          cache: pnpm
+
+      - name: Install Dependencies
+        run: pnpm i
+
+      - name: Run Linters
+        run: pnpm lint

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # eslint-plugin-oxlint
 
-Turn off all rules already supported by `oxlint`. The rules extracted from [here](https://github.com/oxc-project/oxc/blob/main/crates/oxc_linter/src/rules.rs)
+Turn off all rules already supported by `oxlint`. The rules are extracted from [here](https://github.com/oxc-project/oxc/blob/main/crates/oxc_linter/src/rules.rs)
 
 ## What is oxlint?
 
@@ -23,7 +23,7 @@ This plugin is optimized for flat config usage (eslint >= 9.0). See [here](https
 import oxlint from "eslint-plugin-oxlint";
 export default [
   ...// other plugins
-  oxlint, // oxlint should be the last one
+  oxlint.configs["flat/recommended"], // oxlint should be the last one
 ];
 ```
 

--- a/index.cjs
+++ b/index.cjs
@@ -7,10 +7,12 @@ const rules = Object.values(ruleMaps).reduce((accumulator, object) => ({
 }));
 
 module.exports = {
-  rules,
   configs: {
     recommended: {
       plugins: ["oxlint"],
+      rules,
+    },
+    "flat/recommended": {
       rules,
     },
   },

--- a/index.js
+++ b/index.js
@@ -7,10 +7,12 @@ const rules = Object.values(ruleMaps).reduce((accumulator, object) => ({
 }));
 
 export default {
-  rules,
   configs: {
     recommended: {
       plugins: ["oxlint"],
+      rules,
+    },
+    "flat/recommended": {
       rules,
     },
   },


### PR DESCRIPTION
This fixes flat config usage that was broken by my last change -- sorry.

```
✖ eslint:

Oops! Something went wrong! :(

ESLint: 8.56.0

Error: Unexpected key "configs" found.
```

New usage mimics the one of eslint-plugin-unicorn, with 2 exported configs: "flat/recommended" and "recommended".

Also i'm adding a GHA workflow that simply runs a `pnpm lint`, as a "smoke test" to validate further changes. It would have prevented the regression.