### PR TITLE
refactor: Add more types and remove unnecessary `.then()`

### DIFF
--- a/scripts/oxlint-version.ts
+++ b/scripts/oxlint-version.ts
@@ -1,12 +1,10 @@
 import axios from "axios";
 
-export async function getLatestOxlintVersion() {
+export async function getLatestOxlintVersion(): Promise<string> {
   const tagsUrl = "https://api.github.com/repos/oxc-project/oxc/tags";
-  const response = await axios.get(tagsUrl);
-  const tags = response.data.map((tag: any) => tag.name);
-  const oxlintTags: string[] = tags.filter((tag: string) =>
-    tag.startsWith("oxlint_v"),
-  );
+  const { data } = await axios.get<Array<{ name: string }>>(tagsUrl);
+  const tags = data.map((tag) => tag.name);
+  const oxlintTags = tags.filter((tag) => tag.startsWith("oxlint_v"));
   const latestVersion = oxlintTags
     .slice(1)
     .reduce((latest: string, current: string) => {


### PR DESCRIPTION
Hi,

I added a few more type definitions (especially to data returned from `axios`) and a few other improvements.
Feel free to modify this PR if you don't like some of the changes.

Thanks for the plugin and keep up the good work!