### PR TITLE
chore: use dependabot to bump oxlint rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,53 @@
+name: Dependabot Update oxc
+
+on: pull_request
+
+permissions:
+  pull-requests: write
+  contents: write
+
+env:
+  OXLINT_PACKAGE_NAME: oxlint
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    outputs:
+      oxlint-updated: ${{ contains(steps.metadata.outputs.dependency-names, env.OXLINT_PACKAGE_NAME) }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  bump-oxlint-rules:
+    runs-on: ubuntu-latest
+    needs: setup
+    if: needs.setup.outputs.oxlint-updated == 'true'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+
+      - name: Set node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install Dependencies
+        run: pnpm i
+
+      - name: Bump oxlint rules
+        run: |
+          pnpm run generate
+          git config --global user.name "dependabot[bot]"
+          git config --global user.email "49699333+dependabot[bot]@users.noreply.github.com"
+          git commit -am "feat(oxlint): bump oxlint rules"
+          git push


### PR DESCRIPTION
- Enables Dependabot
- Whenever Dependabot updates oxlint, generate rules and push to the same branch.

Test run: 
<img width="887" alt="image" src="https://github.com/oxc-project/eslint-plugin-oxlint/assets/1169844/8006444c-aa29-4929-83b2-cc84b747dd51">
