### PR TITLE
chore(ci): fix dependabot support for oxlint bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,5 +5,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    versioning-strategy: "increase"
     labels:
       - "dependencies"

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -58,3 +58,9 @@ jobs:
           git config --global user.email "49699333+dependabot[bot]@users.noreply.github.com"
           git commit -am "feat(oxlint): bump oxlint rules"
           git push
+
+          # Edit title message for changelog purpose
+          gh pr edit "$PR_URL" --title "feat(oxlint): bump oxlint rules"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - run: npx changelogithub
         continue-on-error: true
         env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Dependencies
         run: pnpm i
@@ -37,4 +37,4 @@ jobs:
       - name: Publish to NPM
         run: pnpm -r publish --access public --no-git-checks
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
- To programmatically advertise that we bumped oxlint, we need to use the "increase" statregy so a user's package manager nows that we need a specific oxlint version and can optimistically fetch it.