### PR TITLE
fix: specify published directories in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,10 @@
       "types": "./lib/rules-by-scope.d.ts"
     }
   },
+  "files": [
+    "lib",
+    "src"
+  ],
   "author": "Dunqing <dengqing0821@gmail.com>",
   "homepage": "https://github.com/oxc-project/eslint-plugin-oxlint",
   "repository": {


### PR DESCRIPTION
The package currently publishes all files, as no `"files"` field is specified in package.json.

![image](https://github.com/user-attachments/assets/75b79375-3119-4b78-81db-529866b35903)

This PR changes the package to only publish `lib`, `src`, `LICENSE`, `package.json`, and `README.md`.

See reference here: https://docs.npmjs.com/cli/v10/configuring-npm/package-json#files