### PR TITLE
ci: fix release workflow condition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   release:
-    if: "contains(github.event.head_commit.message, 'release: v')"
+    if: startsWith(github.event.head_commit.message, 'release')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This job should not have run: https://github.com/oxc-project/eslint-plugin-oxlint/actions/runs/10327248826/job/28592123359

I accidentally put quotes around the [contains](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/expressions#contains) function in #131 - however, removing them generates a YAML error with the colon in `'release: v'` (`"release: v"` also fails). A workaround is to use the [startsWith](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/expressions#startswith) function.