### PR TITLE
feat: add config name for better debug

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,17 +10,21 @@ const allRules: Record<string, string> = Object.assign(
 export default {
   configs: {
     recommended: {
+      name: 'oxlint ignore rules recommended',
       plugins: ['oxlint'],
       rules: ruleMapsByCategory.correctnessRules,
     },
     all: {
+      name: 'oxlint ignore rules all',
       plugins: ['oxlint'],
       rules: allRules,
     },
     'flat/all': {
+      name: 'oxlint ignore rules all',
       rules: allRules,
     },
     'flat/recommended': {
+      name: 'oxlint ignore rules recommended',
       rules: ruleMapsByCategory.correctnessRules,
     },
     ...createFlatRulesConfig(ruleMapsByScope),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,8 +6,12 @@ export function createFlatRulesConfig(rulesModule: { [key: string]: unknown }) {
   for (const key of Object.keys(rulesModule)) {
     if (key.endsWith('Rules')) {
       // Ensure the property is a rules set
-      const flatKey = `flat/${kebabCase(key.replace('Rules', ''))}`; // Create the new key
-      flatRulesConfig[flatKey] = { rules: rulesModule[key] }; // Assign the rules to the new key
+      const ruleName = kebabCase(key.replace('Rules', ''));
+      const flatKey = `flat/${ruleName}`; // Create the new key
+      flatRulesConfig[flatKey] = {
+        name: `oxlint/${ruleName}`,
+        rules: rulesModule[key],
+      }; // Assign the rules to the new key
     }
   }
 


### PR DESCRIPTION
we can have a rule set name while inspect eslint config by `npx eslint --inspect-config`

![CleanShot 2024-08-16 at 10 46 44@2x](https://github.com/user-attachments/assets/1506274b-1103-4104-add0-612ab1598d01)
