### PR TITLE
chore(ci): use eslint with ts config

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,4 +20,4 @@ jobs:
         run: npx oxlint
 
       - name: Run eslint
-        run: npx eslint
+        run: npx eslint --flag unstable_ts_config

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,4 +1,4 @@
-import oxlint from './lib/index.cjs';
+import oxlint from './src/index.ts';
 import unicorn from 'eslint-plugin-unicorn';
 import { FlatCompat } from '@eslint/eslintrc';
 import eslint from '@eslint/js';

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "generate": "node --import @oxc-node/core/register ./scripts/generate.ts && pnpm format",
     "clone": "node --import @oxc-node/core/register ./scripts/sparse-clone.ts",
     "build": "vite build",
-    "lint": "npx oxlint && npx eslint",
+    "lint": "npx oxlint && npx eslint --flag unstable_ts_config",
     "format": "npx prettier --write .",
     "release": "bumpp package.json",
     "prepare": "husky",
@@ -77,7 +77,7 @@
     "vitest": "^2.0.0"
   },
   "lint-staged": {
-    "*.{js,cjs,ts}": "eslint",
+    "*.{js,cjs,ts}": "eslint --flag unstable_ts_config",
     "*": "prettier --ignore-unknown --write"
   },
   "dependencies": {


### PR DESCRIPTION
it looks like eslint is using the builded file. 

Because I want to remove the dist/lib folder, eslint should use the generated index file, not the builded (after generated) one.

