### PR TITLE
feat(build): add flat configs by scope and by category to index.d.ts

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,13 +1,32 @@
 import { kebabCase } from 'scule';
-export function createFlatRulesConfig(rulesModule: { [key: string]: unknown }) {
-  const flatRulesConfig: { [key: string]: unknown } = {}; // Add index signature to allow indexing with a string
+import type { KebabCase } from 'scule';
+
+type WithoutRulesSuffix<T> = T extends `${infer P}Rules` ? P : never;
+
+export function createFlatRulesConfig<
+  InputConfigs extends Record<string, RuleRecord>,
+  RuleRecord extends Record<string, string>,
+  ConfigNameVariable extends keyof InputConfigs,
+  ConfigName extends WithoutRulesSuffix<ConfigNameVariable>,
+  OutputConfigs extends Record<
+    `flat/${KebabCase<ConfigName>}`,
+    {
+      name: string;
+      rules: RuleRecord;
+    }
+  >,
+>(rulesModule: InputConfigs): OutputConfigs {
+  const flatRulesConfig = {} as OutputConfigs;
 
   // Iterate over each property in the rules module
   for (const key of Object.keys(rulesModule)) {
     if (key.endsWith('Rules')) {
       // Ensure the property is a rules set
       const ruleName = kebabCase(key.replace('Rules', ''));
-      const flatKey = `flat/${ruleName}`; // Create the new key
+      const flatKey = `flat/${ruleName}` as `flat/${KebabCase<ConfigName>}`; // Create the new key
+
+      // @ts-ignore TS2322 -- "could be instantiated with a different subtype of constraint".
+      // we do not care at the moment, we only want our index.d.ts to include the names of the config
       flatRulesConfig[flatKey] = {
         name: `oxlint/${ruleName}`,
         rules: rulesModule[key],


### PR DESCRIPTION
![grafik](https://github.com/user-attachments/assets/afe8fb6c-646b-49f7-9e2a-b6625bb81f38)

Sadly the output does not includes the rules at the moment:
```ts
declare const _default: {
    configs: {
        "flat/perf": {
            name: string;
            rules: Record<string, string>;
        };
        "flat/pedantic": {
            name: string;
            rules: Record<string, string>;
        };
        "flat/nursery": {
            name: string;
            rules: Record<string, string>;
        };
        .....
```

Next plan: Updating generator script to support flat config out of the box.
This should also improve the ts definitions for them. My "dirty" fix does not work correctly:

<details><summary>Details</summary>
<p>

```ts
import { kebabCase } from 'scule';
import type { KebabCase } from 'scule';

type WithoutRulesSuffix<T> = T extends `${infer P}Rules` ? P : never;

type StringKeys<objType extends {}> = Array<Extract<keyof objType, string>>;

function replaceRulesSuffix<T extends string>(val: T): WithoutRulesSuffix<T> {
  return val.replace('Rules', '') as WithoutRulesSuffix<T>;
}

export function createFlatRulesConfig<
  InputConfigs extends Record<string, unknown>,
  ConfigNameVariable extends Extract<keyof InputConfigs, string>,
  RuleRecord extends InputConfigs[ConfigNameVariable],
  ConfigName extends WithoutRulesSuffix<ConfigNameVariable>,
  FloatConfigKey extends `flat/${KebabCase<ConfigName>}`,
  OutputConfigs extends Record<
    FloatConfigKey,
    {
      name: `oxlint/${KebabCase<ConfigName>}`;
      rules: RuleRecord;
    }
  >,
>(rulesModule: InputConfigs): OutputConfigs {
  const flatRulesConfig = {} as OutputConfigs;

  // Iterate over each property in the rules module
  for (const key of Object.keys(rulesModule) as StringKeys<InputConfigs>) {
    if (key.endsWith('Rules')) {
      // Ensure the property is a rules set
      const ruleName = kebabCase(replaceRulesSuffix(key));

      // we do not care at the moment, we only want our index.d.ts to include the names of the config
      flatRulesConfig[`flat/${ruleName}`] = {
        name: `oxlint/${ruleName}`,
        rules: rulesModule[key],
      }; // Assign the rules to the new key
    }
  }

  return flatRulesConfig as OutputConfigs;
}

```

</p>
</details> 