### PR TITLE
chore(deps): move scule to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "memfs": "^4.9.2",
     "oxlint": "^0.9.10",
     "prettier": "^3.3.1",
+    "scule": "^1.3.0",
     "shelljs": "^0.8.5",
     "typescript": "^5.4.5",
     "typescript-eslint": "^8.8.1",
@@ -77,9 +78,6 @@
   "lint-staged": {
     "*.{js,cjs,ts}": "eslint --flag unstable_ts_config",
     "*": "prettier --ignore-unknown --write"
-  },
-  "dependencies": {
-    "scule": "^1.3.0"
   },
   "volta": {
     "node": "20.14.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      scule:
-        specifier: ^1.3.0
-        version: 1.3.0
     devDependencies:
       '@eslint/js':
         specifier: ^9.12.0
@@ -57,6 +53,9 @@ importers:
       prettier:
         specifier: ^3.3.1
         version: 3.3.3
+      scule:
+        specifier: ^1.3.0
+        version: 1.3.0
       shelljs:
         specifier: ^0.8.5
         version: 0.8.5


### PR DESCRIPTION
because we removed utils.ts, `scule` is only used in the generator code.