### PR TITLE
chore(ci): allow renovate to update eslint

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,7 @@
     {
       "groupName": "npm packages",
       "matchManagers": ["npm"],
-      "ignoreDeps": ["oxlint", "eslint"]
+      "ignoreDeps": ["oxlint"]
     },
     {
       "groupName": "oxlint",


### PR DESCRIPTION
Because we update eslint  to v9 in #170 we can tell renovate to update it again. Hopefully without BC this time^^