### PR TITLE
fix(traverse): should correctly parse rules with fixability metadata

### DIFF
--- a/scripts/traverse-rules.test.ts
+++ b/scripts/traverse-rules.test.ts
@@ -142,11 +142,21 @@ suite('readFilesRecursively', () => {
       correctness
     )`);
 
+    const ruleWithFixabilityModuleContent = dedent(`declare_oxc_lint!(
+      /// Some Block Content
+      /// ) extra parenthesis to make sure it doesn't catch
+      DefaultCaseLast,
+      correctness,
+      fix
+    )`);
+
     vol.fromJSON({
       'crates/src/rules/eslint/rulename-with-mod/mod.rs':
         ruleNameWithModuleContent,
       'crates/src/rules/typescript/rulename-without-mod.rs':
         ruleNameWithoutModuleContent,
+      'crates/src/rules/unicorn/rule-with-fixability.rs':
+        ruleWithFixabilityModuleContent,
     });
 
     // Call the function
@@ -162,6 +172,11 @@ suite('readFilesRecursively', () => {
         category: 'correctness',
         scope: 'typescript',
         value: '@typescript-eslint/rulename-without-mod',
+      },
+      {
+        category: 'correctness',
+        scope: 'unicorn',
+        value: 'unicorn/rule-with-fixability',
       },
     ]);
 

--- a/scripts/traverse-rules.ts
+++ b/scripts/traverse-rules.ts
@@ -104,9 +104,10 @@ async function processFile(
     // Remove comments to prevent them from affecting the regex
     const cleanBlock = block.replace(/\/\/.*$|\/\*[\S\s]*?\*\//gm, '').trim();
 
-    // Extract the keyword, correctly handling optional trailing characters
+    // Extract the keyword, skipping the optional fixability metadata,
+    // and correctly handling optional trailing characters
     // since trailing commas are optional in Rust and the last keyword may not have one
-    const keywordRegex = /,\s*(\w+)\s*,?\s*$/;
+    const keywordRegex = /,\s*(\w+)\s*,?\s*(?:(\w+)\s*,?\s*)?$/;
     const keywordMatch = keywordRegex.exec(cleanBlock);
 
     if (keywordMatch) {


### PR DESCRIPTION
Fixes #195

The configs needs to be re-generated after this change.