### PR TITLE
fix(ci): do not bump version on generate, let CI manage it

### DIFF
--- a/.github/workflows/bump_oxlint.yml
+++ b/.github/workflows/bump_oxlint.yml
@@ -18,14 +18,18 @@ jobs:
 
       - uses: ./.github/actions/pnpm
 
-      - name: Bump oxlint rules
+      - name: Generate from latest version
         run: |
           pnpm update --latest oxlint
           pnpm run clone
           pnpm run generate # Generate rules from latest oxlint
           pnpm run format # run prettier over it
-          pnpm run test -u # Update test snapshots
-          npm version ${{ inputs.version }} --no-git-tag-version
+
+      - name: Test and update
+        run: pnpm run test -u # Update test snapshots
+
+      - name: Bump oxlint rules
+        run: npm version ${{ inputs.version }} --no-git-tag-version
 
       - uses: peter-evans/create-pull-request@v7
         with:

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -1,10 +1,8 @@
-import { writeFileSync } from 'node:fs';
 import { RulesGenerator, RulesGrouping } from './rules-generator.js';
 import { ConfigGenerator } from './config-generator.js';
 import { traverseRules } from './traverse-rules.js';
 import { getLatestVersionFromClonedRepo } from './oxlint-version.js';
 import { TARGET_DIRECTORY, VERSION_PREFIX } from './constants.js';
-import packageJson from '../package.json' with { type: 'json' };
 
 const { successResultArray, failureResultArray } = await traverseRules();
 
@@ -34,11 +32,3 @@ const configGenerator = new ConfigGenerator(oxlintVersion, successResultArray);
   generator.setRulesGrouping(RulesGrouping.CATEGORY);
   await generator.generateRules();
 });
-// Update package.json version
-writeFileSync(
-  '../package.json',
-  JSON.stringify({
-    ...packageJson,
-    version: oxlintVersion.replace(VERSION_PREFIX, '').split('-')[0],
-  })
-);


### PR DESCRIPTION
closes #198 

Reason: the generate script already bumped the version in the package file. `npm version v0.10.3` did not detect a file change, so it failed.

So we let now the CI manage the package version. Also I made it clearer what happens in the CI 