### PR TITLE
refactor: remove oxlint version from generator

### DIFF
--- a/scripts/config-generator.ts
+++ b/scripts/config-generator.ts
@@ -13,15 +13,12 @@ export enum RulesGrouping {
 export type ResultMap = Map<string, string[]>;
 
 export class ConfigGenerator {
-  private oxlintVersion: string;
   private rulesGrouping: RulesGrouping;
   private rulesArray: Rule[];
   constructor(
-    oxlintVersion: string,
     rulesArray: Rule[] = [],
     rulesGrouping: RulesGrouping = RulesGrouping.SCOPE
   ) {
-    this.oxlintVersion = oxlintVersion;
     this.rulesArray = rulesArray;
     this.rulesGrouping = rulesGrouping;
   }
@@ -46,9 +43,7 @@ export class ConfigGenerator {
   }
 
   public async generateRulesCode() {
-    console.log(
-      `Generating config for ${this.oxlintVersion}, grouped by ${this.rulesGrouping}`
-    );
+    console.log(`Generating config, grouped by ${this.rulesGrouping}`);
 
     const rulesGrouping = this.rulesGrouping;
     const rulesArray = this.rulesArray;

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -1,8 +1,6 @@
 import { RulesGenerator, RulesGrouping } from './rules-generator.js';
 import { ConfigGenerator } from './config-generator.js';
 import { traverseRules } from './traverse-rules.js';
-import { getLatestVersionFromClonedRepo } from './oxlint-version.js';
-import { TARGET_DIRECTORY, VERSION_PREFIX } from './constants.js';
 
 const { successResultArray, failureResultArray } = await traverseRules();
 
@@ -12,19 +10,8 @@ if (failureResultArray.length > 0) {
   );
 }
 
-const oxlintVersion = getLatestVersionFromClonedRepo(
-  TARGET_DIRECTORY,
-  VERSION_PREFIX
-);
-
-if (!oxlintVersion) {
-  throw new Error(
-    'Failed to get the latest version of oxlint, did you forget to run `pnpm clone`?'
-  );
-}
-
-const rulesGenerator = new RulesGenerator(oxlintVersion, successResultArray);
-const configGenerator = new ConfigGenerator(oxlintVersion, successResultArray);
+const rulesGenerator = new RulesGenerator(successResultArray);
+const configGenerator = new ConfigGenerator(successResultArray);
 
 [rulesGenerator, configGenerator].forEach(async (generator) => {
   generator.setRulesGrouping(RulesGrouping.SCOPE);

--- a/scripts/rules-generator.test.ts
+++ b/scripts/rules-generator.test.ts
@@ -29,7 +29,6 @@ suite('RulesGenerator', () => {
 
     // Create an instance of RulesGenerator
     const generator = new RulesGenerator(
-      '1.0.0',
       successResultArray,
       RulesGrouping.SCOPE
     );

--- a/scripts/rules-generator.ts
+++ b/scripts/rules-generator.ts
@@ -13,15 +13,12 @@ export enum RulesGrouping {
 export type ResultMap = Map<string, string[]>;
 
 export class RulesGenerator {
-  private oxlintVersion: string;
   private rulesGrouping: RulesGrouping;
   private rulesArray: Rule[];
   constructor(
-    oxlintVersion: string,
     rulesArray: Rule[] = [],
     rulesGrouping: RulesGrouping = RulesGrouping.SCOPE
   ) {
-    this.oxlintVersion = oxlintVersion;
     this.rulesArray = rulesArray;
     this.rulesGrouping = rulesGrouping;
   }
@@ -46,9 +43,7 @@ export class RulesGenerator {
   }
 
   public async generateRulesCode() {
-    console.log(
-      `Generating rules for ${this.oxlintVersion}, grouped by ${this.rulesGrouping}`
-    );
+    console.log(`Generating rules, grouped by ${this.rulesGrouping}`);
 
     const rulesGrouping = this.rulesGrouping;
     const rulesArray = this.rulesArray;


### PR DESCRIPTION
it is only used for output. after #204 the output does not match always the cloned version