### PR TITLE
ci: improve bump_oxlint, force right version

### DIFF
--- a/.github/workflows/bump_oxlint.yml
+++ b/.github/workflows/bump_oxlint.yml
@@ -18,11 +18,11 @@ jobs:
 
       - uses: ./.github/actions/pnpm
 
-      - name: Generate from latest version
+      - name: Generate version ${{ inputs.version }}
         run: |
-          pnpm update --latest oxlint
-          pnpm run clone
-          pnpm run generate # Generate rules from latest oxlint
+          pnpm install oxlint@${{ inputs.version }}
+          pnpm run clone ${{ inputs.version }}
+          pnpm run generate # Generate rules from source code
           pnpm run format # run prettier over it
 
       - name: Test and update snapshot


### PR DESCRIPTION
this allows us to run manually this job with older version of `oxlint`.

Expected that `inputs.version` is a string in this format: `0.10.3`.

After this merge we can, if we want, create an release `0.10.2` and not get the changes from `0.10.3`