### PR TITLE
fix: add missing types entry in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.11.0",
   "description": "Turn off all rules already supported by oxlint",
   "type": "module",
+  "types": "./dist/index.d.ts",
   "packageManager": "pnpm@9.12.3",
   "exports": {
     ".": {


### PR DESCRIPTION
This change addresses an issue where VSCode (1.9X) could not locate the TypeScript declaration file, resulting in a "Cannot find module "eslint-plugin-oxlint" ts(2307)" error. Adding `"types": "./dist/index.d.ts"` to `package.json` ensures that TypeScript definitions are correctly referenced, enhancing editor support and avoiding import errors in TypeScript projects.
