### PR TITLE
fix: ignore not implemented `import` rules

### DIFF
--- a/scripts/constants.ts
+++ b/scripts/constants.ts
@@ -10,6 +10,12 @@ export const SPARSE_CLONE_DIRECTORY = 'crates/oxc_linter/src';
 // these are the rules that don't have a direct equivalent in the eslint rules
 export const ignoreScope = new Set(['oxc', 'deepscan', 'security']);
 
+// these rules exists in the repo, but are not implemented
+export const ignoreRules = new Set([
+  'import/no-deprecated',
+  'import/no-unused-modules',
+]);
+
 export function convertScope(scope: string) {
   return Reflect.has(aliasPluginNames, scope)
     ? aliasPluginNames[scope as 'eslint']

--- a/scripts/traverse-rules.ts
+++ b/scripts/traverse-rules.ts
@@ -1,6 +1,7 @@
 import { promises } from 'node:fs';
 import path from 'node:path';
 import {
+  ignoreRules,
   ignoreScope,
   prefixScope,
   SPARSE_CLONE_DIRECTORY,
@@ -79,7 +80,7 @@ async function processFile(
 
   // 'ok' way to get the scope, depends on the directory structure
   let scope = getFolderNameUnderRules(filePath);
-  const shouldIgnoreRule = ignoreScope.has(scope);
+  let shouldIgnoreRule = ignoreScope.has(scope);
 
   // when the file is called `mod.rs` we want to use the parent directory name as the rule name
   // Note that this is fairly brittle, as relying on the directory structure can be risky
@@ -99,6 +100,10 @@ async function processFile(
 
   const effectiveRuleName =
     `${prefixScope(scope)}${ruleNameWithoutScope}`.replaceAll('_', '-');
+
+  if (!shouldIgnoreRule) {
+    shouldIgnoreRule = ignoreRules.has(effectiveRuleName);
+  }
 
   // add the rule to the skipped array and continue to see if there's a match regardless
   if (shouldIgnoreRule) {

--- a/src/__snapshots__/build-from-oxlint-config.spec.ts.snap
+++ b/src/__snapshots__/build-from-oxlint-config.spec.ts.snap
@@ -8,8 +8,6 @@ exports[`buildFromOxlintConfig > custom plugins, custom categories > customPlugi
       "constructor-super": "off",
       "getter-return": "off",
       "import/export": "off",
-      "import/no-deprecated": "off",
-      "import/no-unused-modules": "off",
       "no-undef": "off",
       "no-unreachable": "off",
     },

--- a/src/__snapshots__/configs.spec.ts.snap
+++ b/src/__snapshots__/configs.spec.ts.snap
@@ -281,9 +281,6 @@ exports[`contains all the oxlint rules 1`] = `
   "import/no-default-export": [
     0,
   ],
-  "import/no-deprecated": [
-    0,
-  ],
   "import/no-duplicates": [
     0,
   ],
@@ -297,9 +294,6 @@ exports[`contains all the oxlint rules 1`] = `
     0,
   ],
   "import/no-self-import": [
-    0,
-  ],
-  "import/no-unused-modules": [
     0,
   ],
   "import/no-webpack-loader-syntax": [

--- a/src/build-from-oxlint-config.spec.ts
+++ b/src/build-from-oxlint-config.spec.ts
@@ -318,7 +318,7 @@ describe('integration test with oxlint', () => {
     {
       categories: {
         correctness: 'warn',
-        nursery: 'off', // enable after oxc-project/oxc#7073
+        nursery: 'warn',
         pedantic: 'warn',
         perf: 'warn',
         restriction: 'warn',
@@ -341,7 +341,6 @@ describe('integration test with oxlint', () => {
         'promise',
         'jest',
         'vitest',
-        'tree_shaking',
       ],
     },
     // everything on
@@ -359,11 +358,10 @@ describe('integration test with oxlint', () => {
         'promise',
         'jest',
         'vitest',
-        'tree_shaking',
       ],
       categories: {
         correctness: 'warn',
-        nursery: 'off', // enable after oxc-project/oxc#7073
+        nursery: 'off', // ToDo: something with the import plugin
         pedantic: 'warn',
         perf: 'warn',
         restriction: 'warn',

--- a/src/build-from-oxlint-config.spec.ts
+++ b/src/build-from-oxlint-config.spec.ts
@@ -361,7 +361,7 @@ describe('integration test with oxlint', () => {
       ],
       categories: {
         correctness: 'warn',
-        nursery: 'off', // ToDo: something with the import plugin
+        nursery: 'warn',
         pedantic: 'warn',
         perf: 'warn',
         restriction: 'warn',

--- a/src/build-from-oxlint-config.ts
+++ b/src/build-from-oxlint-config.ts
@@ -240,6 +240,12 @@ export const buildFromOxlintConfig = (
   // it is not a plugin but it is activated by default
   plugins.push('eslint');
 
+  // oxc handles "react-hooks" rules inside "react" plugin
+  // our generator split them into own plugins
+  if (plugins.includes('react')) {
+    plugins.push('react-hooks');
+  }
+
   handleCategoriesScope(
     plugins,
     readCategoriesFromConfig(config) ?? defaultCategories,

--- a/src/generated/rules-by-category.ts
+++ b/src/generated/rules-by-category.ts
@@ -84,8 +84,6 @@ const nurseryRules = {
   'no-undef': 'off',
   'no-unreachable': 'off',
   'import/export': 'off',
-  'import/no-deprecated': 'off',
-  'import/no-unused-modules': 'off',
   'promise/no-return-in-finally': 'off',
   'react/require-render-return': 'off',
   'react-hooks/exhaustive-deps': 'off',

--- a/src/generated/rules-by-scope.ts
+++ b/src/generated/rules-by-scope.ts
@@ -129,13 +129,11 @@ const importRules = {
   'import/no-commonjs': 'off',
   'import/no-cycle': 'off',
   'import/no-default-export': 'off',
-  'import/no-deprecated': 'off',
   'import/no-duplicates': 'off',
   'import/no-dynamic-require': 'off',
   'import/no-named-as-default': 'off',
   'import/no-named-as-default-member': 'off',
   'import/no-self-import': 'off',
-  'import/no-unused-modules': 'off',
   'import/no-webpack-loader-syntax': 'off',
   'import/unambiguous': 'off',
 } as const;


### PR DESCRIPTION
I would prefer if they are deleted in oxc project. but this works too :) 