### PR TITLE
chore: update pnpm lock

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -609,14 +609,44 @@ packages:
   '@oxc-node/core@0.0.15':
     resolution: {integrity: sha512-g8ip2dUKtxfZ5IqROmZbHz7OY/+GOG4dnhqgQezlYXCufUcWA+0GM+FqI0ZzA50njUFKCTAHXRiN+BqJPy4trA==}
 
+  '@oxlint/darwin-arm64@0.15.0':
+    resolution: {integrity: sha512-Y4yFRquejyuI/3dyBxLvc8lbwM8Hf/8e0YH9QwQPD9+dgzgOnF818/+OKVE4bDH/V7nWyw4hIQQibMcPvg038g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint/darwin-x64@0.15.0':
+    resolution: {integrity: sha512-l0NksXD2HSzb/u7RXH1kPNtwOXevkvS4vH7pMDiSrfIbtZTx10YgiLy5zFkFbipJRLmIZUdG+9JEjepsy9S3Ig==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint/linux-arm64-gnu@0.15.0':
+    resolution: {integrity: sha512-Yt2LGRfMwPXrMelEqbbkWFcL50ulAUUqMrfcNYB+H/9S8KF4PSMDRm642VV4949xC3XzkjoL3ZMyKQQKMRWC+Q==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxlint/linux-arm64-musl@0.15.0':
+    resolution: {integrity: sha512-+H6CIbejZyE3sc3StoYImqZL3z2zNbv5L547ATLHGyQ5b2JrXMuJ/lqIaNdAa24BehJ6g+/swBIIE5Pk65K3PA==}
+    cpu: [arm64]
+    os: [linux]
+
   '@oxlint/linux-x64-gnu@0.15.0':
     resolution: {integrity: sha512-e/KSj4fg5EFdK/bJLJjGRzaw2KZdYgr2mTt3k9HF9YIGl0UnBoX5h+q0hJ9scDTNNailT8qytvOjuiUhyJpAPA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxlint/linux-x64-musl@0.15.0':
+    resolution: {integrity: sha512-lOXNTYw7kelNkJPQlrLlk5E8f/ROZFcGOGR5VKHCI+/53QTX/WY5kMo7JOaRyJ+jnNdeN1HW70oRQPjtAujjxw==}
     cpu: [x64]
     os: [linux]
 
   '@oxlint/win32-arm64@0.15.0':
     resolution: {integrity: sha512-Hms4Ld6uAOKpbLq27MUqQzffxd71+pK96mzK3YULrkASzIa7AZdtNlRBqfqVRuXCiuxPxT6PhfcriURwsvD/YA==}
     cpu: [arm64]
+    os: [win32]
+
+  '@oxlint/win32-x64@0.15.0':
+    resolution: {integrity: sha512-AF0t15GJLoVcMqvbpHwYFHx2o9HkMuEt6GEipPMZ9gaNx1yp6NrP655jywNzhbKHSd6wxSY+CH7aRI9QjdtG1w==}
+    cpu: [x64]
     os: [win32]
 
   '@pkgjs/parseargs@0.11.0':
@@ -2579,10 +2609,28 @@ snapshots:
       '@oxc-node/core-win32-ia32-msvc': 0.0.15
       '@oxc-node/core-win32-x64-msvc': 0.0.15
 
+  '@oxlint/darwin-arm64@0.15.0':
+    optional: true
+
+  '@oxlint/darwin-x64@0.15.0':
+    optional: true
+
+  '@oxlint/linux-arm64-gnu@0.15.0':
+    optional: true
+
+  '@oxlint/linux-arm64-musl@0.15.0':
+    optional: true
+
   '@oxlint/linux-x64-gnu@0.15.0':
     optional: true
 
+  '@oxlint/linux-x64-musl@0.15.0':
+    optional: true
+
   '@oxlint/win32-arm64@0.15.0':
+    optional: true
+
+  '@oxlint/win32-x64@0.15.0':
     optional: true
 
   '@pkgjs/parseargs@0.11.0':
@@ -3655,8 +3703,14 @@ snapshots:
 
   oxlint@0.15.0:
     optionalDependencies:
+      '@oxlint/darwin-arm64': 0.15.0
+      '@oxlint/darwin-x64': 0.15.0
+      '@oxlint/linux-arm64-gnu': 0.15.0
+      '@oxlint/linux-arm64-musl': 0.15.0
       '@oxlint/linux-x64-gnu': 0.15.0
+      '@oxlint/linux-x64-musl': 0.15.0
       '@oxlint/win32-arm64': 0.15.0
+      '@oxlint/win32-x64': 0.15.0
 
   p-limit@2.3.0:
     dependencies:


### PR DESCRIPTION
just missing bin for other platforms. Do not know how this was auto skipped by release.