### PR TITLE
fix: add `package.json` to the package exports 

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
       "import": "./dist/generated/rules-by-scope.mjs",
       "require": "./dist/generated/rules-by-scope.cjs",
       "default": "./dist/generated/rules-by-scope.mjs"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "dist",


### PR DESCRIPTION
closes #312 

> package.json was not found: Package subpath './package.json' is not defined by "exports"

Some tools like to look into our package.json but we are not currently allowing it.