### PR TITLE
fix: do not output warning when no matching oxlint rule is found

### DIFF
--- a/src/build-from-oxlint-config/rules.ts
+++ b/src/build-from-oxlint-config/rules.ts
@@ -83,9 +83,6 @@ export const handleRulesScope = (
     const eslintName = getEsLintRuleName(rule);
 
     if (eslintName === undefined) {
-      console.warn(
-        `eslint-plugin-oxlint: could not find matching eslint rule for "${rule}"`
-      );
       continue;
     }
 


### PR DESCRIPTION
closes #354 