### PR TITLE
chore(deps): ignore updates for @oxc-node/core and downgrade to 0.0.22

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,7 +8,7 @@
     {
       "groupName": "npm packages",
       "matchManagers": ["npm"],
-      "ignoreDeps": ["oxlint"]
+      "ignoreDeps": ["oxlint", "@oxc-node/core"]
     },
     {
       "groupName": "oxlint",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   ],
   "devDependencies": {
     "@eslint/js": "^9.13.0",
-    "@oxc-node/core": "^0.0.23",
+    "@oxc-node/core": "^0.0.22",
     "@types/eslint-config-prettier": "^6.11.3",
     "@types/node": "^22.7.7",
     "@types/shelljs": "^0.8.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,8 +16,8 @@ importers:
         specifier: ^9.13.0
         version: 9.25.1
       '@oxc-node/core':
-        specifier: ^0.0.23
-        version: 0.0.23
+        specifier: ^0.0.22
+        version: 0.0.22
       '@types/eslint-config-prettier':
         specifier: ^6.11.3
         version: 6.11.3
@@ -402,88 +402,88 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@oxc-node/core-android-arm-eabi@0.0.23':
-    resolution: {integrity: sha512-KVPR2HZ9mYOxdgoDM59ckz8TxeH72CRcdnFu2yOxDyJRwRSz64jCCIZxcgc2PQ7dFpU8r0S71ay+R0QKWs8Qbg==}
+  '@oxc-node/core-android-arm-eabi@0.0.22':
+    resolution: {integrity: sha512-4LI7ywmjE5o2ah98RuPBnhekkBwiGFv9lS7ehJdZMkjLPL5YWkjfBManERg0lbGgAkw13ixSb68lsQXWZkPAzA==}
     cpu: [arm]
     os: [android]
 
-  '@oxc-node/core-android-arm64@0.0.23':
-    resolution: {integrity: sha512-s1517VgPasE22bqEizOKs+c4O0zOAgLXsWPtHrTq8XAZbhKf7eVJyLtZRbnKYD7WTPWb1o3IaGfsglF0JQQd/Q==}
+  '@oxc-node/core-android-arm64@0.0.22':
+    resolution: {integrity: sha512-3mGF2q5B2zhkI260LZSl8lvOYEaxNlGdiHvI6cfBLvtcvAYqWeZuXlm/AlCeHdxNHv485xzf4N17dFIoQlM/Eg==}
     cpu: [arm64]
     os: [android]
 
-  '@oxc-node/core-darwin-arm64@0.0.23':
-    resolution: {integrity: sha512-wo/ZugfeFMX6/+KnZIfWsA9jezBqFWjZnuEiv3D/tesRI1j3vxxPj23TXJNF25uBaM9IzQQHFeBf9Td01gLLIg==}
+  '@oxc-node/core-darwin-arm64@0.0.22':
+    resolution: {integrity: sha512-DDNEev3A7kO6X+QkIEc0sdXippO8EiUKLFS47koR6BZ4DwL1SqfgOl+S3vQH94Pb37JL3zQ2lPXyGylq6TDoXQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxc-node/core-darwin-x64@0.0.23':
-    resolution: {integrity: sha512-JWa1PF+lK31PO1QyjD6L3MsiXA796YjiwDumb9vikwqZJbCav1YEJvY43BzSR7AvnosWg8gNTNJAk03emWak/w==}
+  '@oxc-node/core-darwin-x64@0.0.22':
+    resolution: {integrity: sha512-mx1xk0/KXhUwCzv11Ep4Yx372Nnfiihg/7+Wm426AHFrIfXnf0NLsmq7YjRNXDAY2BrQZrG9A8m68QqMOsca3g==}
     cpu: [x64]
     os: [darwin]
 
-  '@oxc-node/core-freebsd-x64@0.0.23':
-    resolution: {integrity: sha512-F3/xYyv//61puQN95VRQfyFRHQ6DhObd2q54/h4yP4ioKhFfErEN2pspZzXu2S0szfxN0oYT52M8uJB9mz2/lQ==}
+  '@oxc-node/core-freebsd-x64@0.0.22':
+    resolution: {integrity: sha512-oUNA9yk+4QLlkZw40kWryB1pgS4x9uaM5kveS87xmx8QPta2lRrDGvakzd6dyi74oYSzgxUs2NPhLIm37F5TlA==}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxc-node/core-linux-arm-gnueabihf@0.0.23':
-    resolution: {integrity: sha512-WyaCm9uIYA5CyvVRNNDlyRhPz3OKAhK77OjshQ3ACaarTui3cQ1GeSBxxpPiEmMdWr3SEA7n28ynvrXsPzkzvw==}
+  '@oxc-node/core-linux-arm-gnueabihf@0.0.22':
+    resolution: {integrity: sha512-5lotf6sz+T7jj2UcQvaCpdJHby6aK0w1Fm+wI2bOcKIxY1aHwV9ICRCp9krbmCEWA6T9ZhnXw7vXnubP8f5NpQ==}
     cpu: [arm]
     os: [linux]
 
-  '@oxc-node/core-linux-arm64-gnu@0.0.23':
-    resolution: {integrity: sha512-x/KFcQbHhTFzKGRDE/eL7LdkeZU9BmclxlKugYbsJhUYr4pRA6GKThTEz7vFYm7CWlMxzhq8IgKWwHfm1T0BKg==}
+  '@oxc-node/core-linux-arm64-gnu@0.0.22':
+    resolution: {integrity: sha512-EOrnT5a53kGoChMLh5b9AKfLWxGGmIsGRwJQzsVqEY4pK+OXlLtykgteEFbloboSGJGBBYY725x63s3g+NpqPQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@oxc-node/core-linux-arm64-musl@0.0.23':
-    resolution: {integrity: sha512-ujsdd24zJzYqshzuqjSFZIWT8KZI9PWKI8m36qbdeE4TbKSlGAaJbbMwA/RS2ZfzHFhNCLDAaQxX6N2llfgPCQ==}
+  '@oxc-node/core-linux-arm64-musl@0.0.22':
+    resolution: {integrity: sha512-4OJ09Alo8TwNJJbutu2zKg8Vu3+ZYwejQs6pHNZIouoqqpVb5lFUpKU5dZKJ0v1TcvDSbIoK3+boOP7Rvh9KLA==}
     cpu: [arm64]
     os: [linux]
 
-  '@oxc-node/core-linux-ppc64-gnu@0.0.23':
-    resolution: {integrity: sha512-MjwbpDIPSRpihK/VTvhBeRKJCXKY0x9PRGFeUEBYOHmaZmX7YEJvJViqJHrDu7ZttRmHwPwumrdN71skDnEqFw==}
+  '@oxc-node/core-linux-ppc64-gnu@0.0.22':
+    resolution: {integrity: sha512-aWQGDDZ8cmrEYtRu8JjTAqZh9kuMj0qB3SsaSKFTGtgVdePERBbKFsurm43bLaO4It4KaqV51HWs+lonyMieMQ==}
     cpu: [ppc64]
     os: [linux]
 
-  '@oxc-node/core-linux-s390x-gnu@0.0.23':
-    resolution: {integrity: sha512-UFwpqXY8ESq0S1UQLOV+i0qq+8b2Rr39fqVNOxcLDwRpCKF8EGbZyO2byJljci1+zAPK8Bl9mXpwwVLMs+TctA==}
+  '@oxc-node/core-linux-s390x-gnu@0.0.22':
+    resolution: {integrity: sha512-I47rPXnaH+OxYhcAnib3iJbhOTjKyoFrmwQBKMN6m3jGHRfwSgqOxoYJ/NLKff3Kguk0KMAfBWI7poPe/udarQ==}
     cpu: [s390x]
     os: [linux]
 
-  '@oxc-node/core-linux-x64-gnu@0.0.23':
-    resolution: {integrity: sha512-fm91kTpC6f2BxgPm3Z4As8V3xtH34jvxcv1/ZQMtC2ZXDIMrPdYAd8/CbGUni4FhaEMp0GwBGqYllNj9AWX3Iw==}
+  '@oxc-node/core-linux-x64-gnu@0.0.22':
+    resolution: {integrity: sha512-ER2sVrodkZPDnCC26rzM3A93T/xfKU4I5eg90lueE8fB9U9Wavrnj24AVtGQExJshNG9kc43fAntw1TFM5sNiQ==}
     cpu: [x64]
     os: [linux]
 
-  '@oxc-node/core-linux-x64-musl@0.0.23':
-    resolution: {integrity: sha512-b+OF7y4yHyCzJC2cmnSeFzdTyTdlYHk9K5xHbm3Z+mUqW8D6Gww72yF7SGPcEMEGaktieRJoJeVEfn9uOeFebw==}
+  '@oxc-node/core-linux-x64-musl@0.0.22':
+    resolution: {integrity: sha512-J532Zw7kDkQg6VzCO8EeBNYWWAWlCB4nFWRI41RnMu+XOYOfY56aqzFGO3ImWexVzGZwv9MIgiGCHTGDxJePVw==}
     cpu: [x64]
     os: [linux]
 
-  '@oxc-node/core-wasm32-wasi@0.0.23':
-    resolution: {integrity: sha512-aJZI9wDI5eBDYdDQ3TqYnq6aJ0gfCgU2062QHpO7HDkCX/SRbw4bpxAfArbQz1vPS3mFkOSVx5L4vKaNRvaZVQ==}
+  '@oxc-node/core-wasm32-wasi@0.0.22':
+    resolution: {integrity: sha512-YxrJ+XnwRJhfiHeqaWyPjdIM0k9WsuS1MRF02vzALxDpEKlHtIY39kV3PxAzu8xLHM0AMr5K4yihAEDaKPPQog==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
-  '@oxc-node/core-win32-arm64-msvc@0.0.23':
-    resolution: {integrity: sha512-yLpb7Z9BQJmXicu305/rC5eGjy/R7j4AWuerNYQuKRqryjsOhjD6J0nnwlOj+qYGG/U+yWdP5r9hg+OHBzcQ4A==}
+  '@oxc-node/core-win32-arm64-msvc@0.0.22':
+    resolution: {integrity: sha512-2zaLEfZXvVkKO4YJcn2O2RhCTsG2xSgoJBy+ndtAe1Im/kCpk14YQZNuYvINMoPUVfZdgmKf9jGoT/s4vOaRWA==}
     cpu: [arm64]
     os: [win32]
 
-  '@oxc-node/core-win32-ia32-msvc@0.0.23':
-    resolution: {integrity: sha512-nVnzvQC0y7gUQWRa48eJUzKyaEFRRiRtKhoWoXCfFe1LzAWNKppyFwzmt8kwlsmJFjqnl4RpjNPk+HIHnNE1Hw==}
+  '@oxc-node/core-win32-ia32-msvc@0.0.22':
+    resolution: {integrity: sha512-f7mW4r74fDQdVwO2MDFBeL7QOl2G36ZeG13Xu57VDMD8KPV2tbrXhC9RcC8+YvEWCYwJYQNG5GFUj5zkwXlA3g==}
     cpu: [ia32]
     os: [win32]
 
-  '@oxc-node/core-win32-x64-msvc@0.0.23':
-    resolution: {integrity: sha512-S88EHX7n3WISr+yCaQ7pyTVSI0ESOCZKfuWz882F5ubQjP6OxqCigdEg3ddJ9PUF4xEgDRLBqxn14/scBf8gDQ==}
+  '@oxc-node/core-win32-x64-msvc@0.0.22':
+    resolution: {integrity: sha512-9LG/FtWSl7bW3pQOm3JJ2LgsklMuzA9QwO+2AZPYDxRn9fig0LEuCVACqdtZvqS8155Nl807tIn7bXiUkrZ8vA==}
     cpu: [x64]
     os: [win32]
 
-  '@oxc-node/core@0.0.23':
-    resolution: {integrity: sha512-1UyURTZf97mu/HEcZNopd1SMJ7sz4zdXwN6r205tMeLOdBHLH9Ljphpvfy5fh03pccxXYYrq1YxO2HLgDKgJ8A==}
+  '@oxc-node/core@0.0.22':
+    resolution: {integrity: sha512-hNzc3XlaVaYrixUZSWcXqHRRDSiFw6zYNyyqBLoxzlpCnjjO1RHh4zZaV5KNfJ9iDdiH693+DHRkmyWTU3XDnQ==}
 
   '@oxc-project/runtime@0.62.0':
     resolution: {integrity: sha512-l6nPv12hDRhJnE3IPxzLjWpACpIQYUQFO8tSax6ky61+FJsy+uOAehZWugirfJWN0Pvc2gtXcHpwaOOtP5y4tA==}
@@ -2358,77 +2358,77 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@oxc-node/core-android-arm-eabi@0.0.23':
+  '@oxc-node/core-android-arm-eabi@0.0.22':
     optional: true
 
-  '@oxc-node/core-android-arm64@0.0.23':
+  '@oxc-node/core-android-arm64@0.0.22':
     optional: true
 
-  '@oxc-node/core-darwin-arm64@0.0.23':
+  '@oxc-node/core-darwin-arm64@0.0.22':
     optional: true
 
-  '@oxc-node/core-darwin-x64@0.0.23':
+  '@oxc-node/core-darwin-x64@0.0.22':
     optional: true
 
-  '@oxc-node/core-freebsd-x64@0.0.23':
+  '@oxc-node/core-freebsd-x64@0.0.22':
     optional: true
 
-  '@oxc-node/core-linux-arm-gnueabihf@0.0.23':
+  '@oxc-node/core-linux-arm-gnueabihf@0.0.22':
     optional: true
 
-  '@oxc-node/core-linux-arm64-gnu@0.0.23':
+  '@oxc-node/core-linux-arm64-gnu@0.0.22':
     optional: true
 
-  '@oxc-node/core-linux-arm64-musl@0.0.23':
+  '@oxc-node/core-linux-arm64-musl@0.0.22':
     optional: true
 
-  '@oxc-node/core-linux-ppc64-gnu@0.0.23':
+  '@oxc-node/core-linux-ppc64-gnu@0.0.22':
     optional: true
 
-  '@oxc-node/core-linux-s390x-gnu@0.0.23':
+  '@oxc-node/core-linux-s390x-gnu@0.0.22':
     optional: true
 
-  '@oxc-node/core-linux-x64-gnu@0.0.23':
+  '@oxc-node/core-linux-x64-gnu@0.0.22':
     optional: true
 
-  '@oxc-node/core-linux-x64-musl@0.0.23':
+  '@oxc-node/core-linux-x64-musl@0.0.22':
     optional: true
 
-  '@oxc-node/core-wasm32-wasi@0.0.23':
+  '@oxc-node/core-wasm32-wasi@0.0.22':
     dependencies:
       '@napi-rs/wasm-runtime': 0.2.9
     optional: true
 
-  '@oxc-node/core-win32-arm64-msvc@0.0.23':
+  '@oxc-node/core-win32-arm64-msvc@0.0.22':
     optional: true
 
-  '@oxc-node/core-win32-ia32-msvc@0.0.23':
+  '@oxc-node/core-win32-ia32-msvc@0.0.22':
     optional: true
 
-  '@oxc-node/core-win32-x64-msvc@0.0.23':
+  '@oxc-node/core-win32-x64-msvc@0.0.22':
     optional: true
 
-  '@oxc-node/core@0.0.23':
+  '@oxc-node/core@0.0.22':
     dependencies:
       '@oxc-project/runtime': 0.62.0
       pirates: 4.0.7
     optionalDependencies:
-      '@oxc-node/core-android-arm-eabi': 0.0.23
-      '@oxc-node/core-android-arm64': 0.0.23
-      '@oxc-node/core-darwin-arm64': 0.0.23
-      '@oxc-node/core-darwin-x64': 0.0.23
-      '@oxc-node/core-freebsd-x64': 0.0.23
-      '@oxc-node/core-linux-arm-gnueabihf': 0.0.23
-      '@oxc-node/core-linux-arm64-gnu': 0.0.23
-      '@oxc-node/core-linux-arm64-musl': 0.0.23
-      '@oxc-node/core-linux-ppc64-gnu': 0.0.23
-      '@oxc-node/core-linux-s390x-gnu': 0.0.23
-      '@oxc-node/core-linux-x64-gnu': 0.0.23
-      '@oxc-node/core-linux-x64-musl': 0.0.23
-      '@oxc-node/core-wasm32-wasi': 0.0.23
-      '@oxc-node/core-win32-arm64-msvc': 0.0.23
-      '@oxc-node/core-win32-ia32-msvc': 0.0.23
-      '@oxc-node/core-win32-x64-msvc': 0.0.23
+      '@oxc-node/core-android-arm-eabi': 0.0.22
+      '@oxc-node/core-android-arm64': 0.0.22
+      '@oxc-node/core-darwin-arm64': 0.0.22
+      '@oxc-node/core-darwin-x64': 0.0.22
+      '@oxc-node/core-freebsd-x64': 0.0.22
+      '@oxc-node/core-linux-arm-gnueabihf': 0.0.22
+      '@oxc-node/core-linux-arm64-gnu': 0.0.22
+      '@oxc-node/core-linux-arm64-musl': 0.0.22
+      '@oxc-node/core-linux-ppc64-gnu': 0.0.22
+      '@oxc-node/core-linux-s390x-gnu': 0.0.22
+      '@oxc-node/core-linux-x64-gnu': 0.0.22
+      '@oxc-node/core-linux-x64-musl': 0.0.22
+      '@oxc-node/core-wasm32-wasi': 0.0.22
+      '@oxc-node/core-win32-arm64-msvc': 0.0.22
+      '@oxc-node/core-win32-ia32-msvc': 0.0.22
+      '@oxc-node/core-win32-x64-msvc': 0.0.22
 
   '@oxc-project/runtime@0.62.0': {}
 


### PR DESCRIPTION
see reasons here: https://github.com/oxc-project/oxc-node/issues/109