### PR TITLE
feat: support extends configuration from oxlint config content

### DIFF
--- a/src/build-from-oxlint-config/categories.ts
+++ b/src/build-from-oxlint-config/categories.ts
@@ -7,6 +7,11 @@ import {
 } from './types.js';
 import { isObject } from './utilities.js';
 
+// default categories, see <https://github.com/oxc-project/oxc/blob/0acca58/crates/oxc_linter/src/builder.rs#L82>
+export const defaultCategories: OxlintConfigCategories = {
+  correctness: 'warn',
+};
+
 /**
  * appends all rules which are enabled by a plugin and falls into a specific category
  */

--- a/src/build-from-oxlint-config/extends.spec.ts
+++ b/src/build-from-oxlint-config/extends.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { handleExtendsScope } from './extends.js';
 import { OxlintConfig } from './types.js';
 
-describe.only('handleExtendsScope', () => {
+describe('handleExtendsScope', () => {
   it('should handle empty extends configs', () => {
     const extendsConfigs: OxlintConfig[] = [];
     const config: OxlintConfig = {

--- a/src/build-from-oxlint-config/extends.spec.ts
+++ b/src/build-from-oxlint-config/extends.spec.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import { handleExtendsScope } from './extends.js';
+import { OxlintConfig } from './types.js';
+
+describe.only('handleExtendsScope', () => {
+  it('should handle empty extends configs', () => {
+    const extendsConfigs: OxlintConfig[] = [];
+    const config: OxlintConfig = {
+      plugins: ['react'],
+      categories: { correctness: 'warn' },
+      rules: { eqeqeq: 'error' },
+    };
+    handleExtendsScope(extendsConfigs, config);
+    expect(config).toEqual(config);
+  });
+
+  it('should merge extends configs', () => {
+    const extendsConfigs: OxlintConfig[] = [
+      {
+        plugins: ['react', 'unicorn'],
+        categories: { correctness: 'error' },
+        rules: { rule1: 'error' },
+      },
+    ];
+    const config: OxlintConfig = {
+      categories: { correctness: 'warn' },
+      rules: { rule3: 'warn' },
+    };
+    handleExtendsScope(extendsConfigs, config);
+    expect(config).toEqual({
+      plugins: ['react', 'unicorn'],
+      categories: config.categories,
+      rules: { rule1: 'error', rule3: 'warn' },
+    });
+  });
+
+  it('should merge extends and de duplicate plugins and rules', () => {
+    const extendsConfigs: OxlintConfig[] = [
+      {
+        plugins: ['react', 'typescript'],
+        categories: { correctness: 'error' },
+        rules: { rule1: 'error', rule2: 'error' },
+      },
+    ];
+    const config: OxlintConfig = {
+      plugins: ['react', 'unicorn'],
+      categories: { correctness: 'warn' },
+      rules: { rule1: 'warn' },
+    };
+    handleExtendsScope(extendsConfigs, config);
+    expect(config).toEqual({
+      plugins: ['react', 'typescript', 'unicorn'],
+      categories: config.categories,
+      rules: { rule1: 'warn', rule2: 'error' },
+    });
+  });
+
+  it('should merge multiple extends configs', () => {
+    const extendsConfigs: OxlintConfig[] = [
+      {
+        plugins: ['react', 'unicorn'],
+        categories: { correctness: 'error' },
+        rules: { rule1: 'error', rule2: 'error' },
+      },
+      {
+        plugins: ['typescript'],
+        overrides: [{ files: ['*.ts'], rules: { rule3: 'error' } }],
+      },
+    ];
+    const config: OxlintConfig = {
+      plugins: ['react', 'vitest'],
+      categories: { correctness: 'warn' },
+      rules: { rule1: 'warn' },
+    };
+    handleExtendsScope(extendsConfigs, config);
+    expect(config).toEqual({
+      plugins: ['typescript', 'react', 'unicorn', 'vitest'],
+      categories: config.categories,
+      rules: { rule1: 'warn', rule2: 'error' },
+      overrides: [{ files: ['*.ts'], rules: { rule3: 'error' } }],
+    });
+  });
+
+  it('should merge multiple extends configs with multiple overrides', () => {
+    const extendsConfigs: OxlintConfig[] = [
+      {
+        plugins: ['react', 'unicorn'],
+        categories: { correctness: 'error' },
+        rules: { rule1: 'error', rule2: 'error' },
+      },
+      {
+        plugins: ['typescript'],
+        overrides: [{ files: ['*.ts'], rules: { rule3: 'error' } }],
+      },
+    ];
+    const config: OxlintConfig = {
+      plugins: ['react', 'vitest'],
+      categories: { correctness: 'warn' },
+      rules: { rule1: 'warn' },
+      overrides: [{ files: ['*.spec.ts'], rules: { rule4: 'error' } }],
+    };
+    handleExtendsScope(extendsConfigs, config);
+    expect(config).toEqual({
+      plugins: ['typescript', 'react', 'unicorn', 'vitest'],
+      categories: config.categories,
+      rules: { rule1: 'warn', rule2: 'error' },
+      overrides: [
+        { files: ['*.ts'], rules: { rule3: 'error' } },
+        { files: ['*.spec.ts'], rules: { rule4: 'error' } },
+      ],
+    });
+  });
+});

--- a/src/build-from-oxlint-config/extends.spec.ts
+++ b/src/build-from-oxlint-config/extends.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { handleExtendsScope } from './extends.js';
+import { handleExtendsScope, resolveRelativeExtendsPaths } from './extends.js';
 import { OxlintConfig } from './types.js';
 
 describe('handleExtendsScope', () => {
@@ -109,5 +109,27 @@ describe('handleExtendsScope', () => {
         { files: ['*.spec.ts'], rules: { rule4: 'error' } },
       ],
     });
+  });
+});
+
+describe('resolveRelativeExtendsPaths', () => {
+  it('should resolve relative paths', () => {
+    const config: OxlintConfig = {
+      extends: [
+        './extends1.json',
+        './folder/extends2.json',
+        '../parent/extends3.json',
+      ],
+      __misc: {
+        filePath: '/root/of/the/file/test-config.json',
+      },
+    };
+    resolveRelativeExtendsPaths(config);
+
+    expect(config.extends).toEqual([
+      '/root/of/the/file/extends1.json',
+      '/root/of/the/file/folder/extends2.json',
+      '/root/of/the/parent/extends3.json',
+    ]);
   });
 });

--- a/src/build-from-oxlint-config/extends.ts
+++ b/src/build-from-oxlint-config/extends.ts
@@ -6,7 +6,7 @@ import type {
   OxlintConfigRules,
 } from './types.js';
 import { getConfigContent } from './utilities.js';
-import { readPluginsFromConfig } from './plugins.js';
+import { defaultPlugins, readPluginsFromConfig } from './plugins.js';
 import { readRulesFromConfig } from './rules.js';
 import { readOverridesFromConfig } from './overrides.js';
 
@@ -36,7 +36,7 @@ export const handleExtendsScope = (
   const overrides: OxlintConfigOverride[] =
     readOverridesFromConfig(config) ?? [];
   for (const extendConfig of extendsConfigs) {
-    plugins.unshift(...(readPluginsFromConfig(extendConfig) ?? []));
+    plugins.unshift(...(readPluginsFromConfig(extendConfig) ?? defaultPlugins));
     rules = { ...readRulesFromConfig(extendConfig), ...rules };
     overrides.unshift(...(readOverridesFromConfig(extendConfig) ?? []));
   }

--- a/src/build-from-oxlint-config/extends.ts
+++ b/src/build-from-oxlint-config/extends.ts
@@ -1,0 +1,69 @@
+import fs from 'node:fs';
+import type {
+  OxlintConfig,
+  OxlintConfigOverride,
+  OxlintConfigPlugins,
+  OxlintConfigRules,
+} from './types.js';
+import { getConfigContent } from './utilities.js';
+import { readPluginsFromConfig } from './plugins.js';
+import { readRulesFromConfig } from './rules.js';
+import { readOverridesFromConfig } from './overrides.js';
+
+/**
+ * Checks if the given path is a file.
+ *
+ * @param path - The path to check.
+ * @returns `true` if the path is a file, `false` otherwise.
+ */
+const isFile = (path: string) => {
+  try {
+    return fs.statSync(path).isFile();
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Appends plugins, rules and overrides from the extends configs files to the given config.
+ */
+export const handleExtendsScope = (
+  extendsConfigs: OxlintConfig[],
+  config: OxlintConfig
+) => {
+  let rules: OxlintConfigRules = readRulesFromConfig(config) ?? {};
+  const plugins: OxlintConfigPlugins = readPluginsFromConfig(config) ?? [];
+  const overrides: OxlintConfigOverride[] =
+    readOverridesFromConfig(config) ?? [];
+  for (const extendConfig of extendsConfigs) {
+    plugins.unshift(...(readPluginsFromConfig(extendConfig) ?? []));
+    rules = { ...readRulesFromConfig(extendConfig), ...rules };
+    overrides.unshift(...(readOverridesFromConfig(extendConfig) ?? []));
+  }
+  if (plugins.length > 0) config.plugins = [...new Set(plugins)];
+  if (Object.keys(rules).length > 0) config.rules = rules;
+  if (overrides.length > 0) config.overrides = overrides;
+};
+
+/**
+ * tries to return the content of the chain "extends" section from the config.
+ * it returns `undefined` when not found or invalid and ignores non file paths.
+ */
+export const readExtendsConfigsFromConfig = (
+  config: OxlintConfig
+): OxlintConfig[] | undefined => {
+  if (!('extends' in config) || !Array.isArray(config.extends)) {
+    return undefined;
+  }
+  const extendsConfigs: OxlintConfig[] = [];
+  for (const file of config.extends) {
+    if (!isFile(file)) continue; // ignore non file paths
+    const extendConfig = getConfigContent(file);
+    if (!extendConfig) continue;
+    extendsConfigs.push(
+      extendConfig,
+      ...(readExtendsConfigsFromConfig(extendConfig) ?? [])
+    );
+  }
+  return extendsConfigs;
+};

--- a/src/build-from-oxlint-config/extends.ts
+++ b/src/build-from-oxlint-config/extends.ts
@@ -1,11 +1,10 @@
-import fs from 'node:fs';
 import path from 'node:path';
 import type {
   OxlintConfig,
   OxlintConfigOverride,
   OxlintConfigPlugins,
   OxlintConfigRules,
-  OxlintExtendsConfigs,
+  OxlintConfigExtends,
 } from './types.js';
 import { getConfigContent } from './utilities.js';
 import { defaultPlugins, readPluginsFromConfig } from './plugins.js';
@@ -13,47 +12,31 @@ import { readRulesFromConfig } from './rules.js';
 import { readOverridesFromConfig } from './overrides.js';
 
 /**
- * Checks if the given path is a file.
- *
- * @param path - The path to check.
- * @returns `true` if the path is a file, `false` otherwise.
- */
-const isFile = (path: string) => {
-  try {
-    return fs.statSync(path).isFile();
-  } catch {
-    return false;
-  }
-};
-
-/**
  * tries to return the "extends" section from the config.
  * it returns `undefined` when not found or invalid.
  */
 const readExtendsFromConfig = (
   config: OxlintConfig
-): OxlintExtendsConfigs | undefined => {
+): OxlintConfigExtends | undefined => {
   return 'extends' in config && Array.isArray(config.extends)
-    ? (config.extends as OxlintExtendsConfigs)
+    ? (config.extends as OxlintConfigExtends)
     : undefined;
 };
 
 /**
  * Resolves the paths of the "extends" section relative to the given config file.
  */
-export const resolveRelativeExtendsPaths = (
-  config: OxlintConfig,
-  configFile: string
-) => {
+export const resolveRelativeExtendsPaths = (config: OxlintConfig) => {
+  if (!config.__misc?.filePath) {
+    return;
+  }
+
   const extendsFiles = readExtendsFromConfig(config);
-  if (!extendsFiles || extendsFiles.length === 0) return;
-  const configFileDirectory = path.dirname(path.resolve(configFile));
-  config.extends = extendsFiles.map((extendFile) => {
-    if (isFile(extendFile)) {
-      return path.resolve(configFileDirectory, extendFile);
-    }
-    return extendFile;
-  });
+  if (!extendsFiles?.length) return;
+  const configFileDirectory = path.dirname(config.__misc.filePath);
+  config.extends = extendsFiles.map((extendFile) =>
+    path.resolve(configFileDirectory, extendFile)
+  );
 };
 
 /**
@@ -79,22 +62,27 @@ export const handleExtendsScope = (
 
 /**
  * tries to return the content of the chain "extends" section from the config.
- * it returns `undefined` when not found or invalid and ignores non file paths.
  */
 export const readExtendsConfigsFromConfig = (
   config: OxlintConfig
-): OxlintConfig[] | undefined => {
+): OxlintConfig[] => {
   const extendsFiles = readExtendsFromConfig(config);
-  if (!extendsFiles || extendsFiles.length === 0) return undefined;
+  if (!extendsFiles?.length) return [];
+
   const extendsConfigs: OxlintConfig[] = [];
   for (const file of extendsFiles) {
-    if (!isFile(file)) continue; // ignore non file paths
     const extendConfig = getConfigContent(file);
     if (!extendConfig) continue;
-    resolveRelativeExtendsPaths(extendConfig, file);
+
+    extendConfig.__misc = {
+      filePath: file,
+    };
+
+    resolveRelativeExtendsPaths(extendConfig);
+
     extendsConfigs.push(
       extendConfig,
-      ...(readExtendsConfigsFromConfig(extendConfig) ?? [])
+      ...readExtendsConfigsFromConfig(extendConfig)
     );
   }
   return extendsConfigs;

--- a/src/build-from-oxlint-config/index.ts
+++ b/src/build-from-oxlint-config/index.ts
@@ -1,15 +1,11 @@
-import {
-  EslintPluginOxlintConfig,
-  OxlintConfig,
-  OxlintConfigCategories,
-  OxlintConfigPlugins,
-} from './types.js';
+import { EslintPluginOxlintConfig, OxlintConfig } from './types.js';
 import { handleRulesScope, readRulesFromConfig } from './rules.js';
 import {
+  defaultCategories,
   handleCategoriesScope,
   readCategoriesFromConfig,
 } from './categories.js';
-import { readPluginsFromConfig } from './plugins.js';
+import { defaultPlugins, readPluginsFromConfig } from './plugins.js';
 import {
   handleIgnorePatternsScope,
   readIgnorePatternsFromConfig,
@@ -18,12 +14,6 @@ import { handleOverridesScope, readOverridesFromConfig } from './overrides.js';
 import { splitDisabledRulesForVueAndSvelteFiles } from '../config-helper.js';
 import { handleExtendsScope, readExtendsConfigsFromConfig } from './extends.js';
 import { getConfigContent } from './utilities.js';
-
-// default plugins, see <https://oxc.rs/docs/guide/usage/linter/config#plugins>
-const defaultPlugins: OxlintConfigPlugins = ['react', 'unicorn', 'typescript'];
-
-// default categories, see <https://github.com/oxc-project/oxc/blob/0acca58/crates/oxc_linter/src/builder.rs#L82>
-const defaultCategories: OxlintConfigCategories = { correctness: 'warn' };
 
 /**
  * builds turned off rules, which are supported by oxlint.

--- a/src/build-from-oxlint-config/index.ts
+++ b/src/build-from-oxlint-config/index.ts
@@ -18,6 +18,7 @@ import {
   resolveRelativeExtendsPaths,
 } from './extends.js';
 import { getConfigContent } from './utilities.js';
+import path from 'node:path';
 
 /**
  * builds turned off rules, which are supported by oxlint.
@@ -26,8 +27,10 @@ import { getConfigContent } from './utilities.js';
 export const buildFromOxlintConfig = (
   config: OxlintConfig
 ): EslintPluginOxlintConfig[] => {
+  resolveRelativeExtendsPaths(config);
+
   const extendConfigs = readExtendsConfigsFromConfig(config);
-  if (extendConfigs !== undefined && extendConfigs.length > 0) {
+  if (extendConfigs.length > 0) {
     handleExtendsScope(extendConfigs, config);
   }
 
@@ -93,7 +96,9 @@ export const buildFromOxlintConfigFile = (
     return [];
   }
 
-  resolveRelativeExtendsPaths(config, oxlintConfigFile);
+  config.__misc = {
+    filePath: path.resolve(oxlintConfigFile),
+  };
 
   return buildFromOxlintConfig(config);
 };

--- a/src/build-from-oxlint-config/index.ts
+++ b/src/build-from-oxlint-config/index.ts
@@ -12,7 +12,11 @@ import {
 } from './ignore-patterns.js';
 import { handleOverridesScope, readOverridesFromConfig } from './overrides.js';
 import { splitDisabledRulesForVueAndSvelteFiles } from '../config-helper.js';
-import { handleExtendsScope, readExtendsConfigsFromConfig } from './extends.js';
+import {
+  handleExtendsScope,
+  readExtendsConfigsFromConfig,
+  resolveRelativeExtendsPaths,
+} from './extends.js';
 import { getConfigContent } from './utilities.js';
 
 /**
@@ -88,6 +92,8 @@ export const buildFromOxlintConfigFile = (
   if (config === undefined) {
     return [];
   }
+
+  resolveRelativeExtendsPaths(config, oxlintConfigFile);
 
   return buildFromOxlintConfig(config);
 };

--- a/src/build-from-oxlint-config/index.ts
+++ b/src/build-from-oxlint-config/index.ts
@@ -44,6 +44,33 @@ const getConfigContent = (
         throw new TypeError('not an valid config file');
       }
 
+      if ('extends' in configContent && Array.isArray(configContent.extends)) {
+        for (const extendFile of configContent.extends) {
+          const extendsContent = getConfigContent(extendFile);
+          if (!extendsContent) continue;
+          if (extendsContent.plugins) {
+            configContent.plugins = [
+              ...extendsContent.plugins,
+              ...(configContent.plugins ?? []),
+            ];
+          }
+          if (extendsContent.rules)
+            configContent.rules = {
+              ...extendsContent.rules,
+              ...configContent.rules,
+            };
+          if (
+            'overrides' in extendsContent &&
+            Array.isArray(extendsContent.overrides)
+          ) {
+            configContent.overrides = [
+              ...extendsContent.overrides,
+              ...(configContent.overrides ?? []),
+            ];
+          }
+        }
+      }
+
       return configContent;
     } catch {
       console.error(

--- a/src/build-from-oxlint-config/plugins.ts
+++ b/src/build-from-oxlint-config/plugins.ts
@@ -4,6 +4,13 @@ import {
   OxlintConfigPlugins,
 } from './types.js';
 
+// default plugins, see <https://oxc.rs/docs/guide/usage/linter/config#plugins>
+export const defaultPlugins: OxlintConfigPlugins = [
+  'react',
+  'unicorn',
+  'typescript',
+];
+
 /**
  * tries to return the "plugins" section from the config.
  * it returns `undefined` when not found or invalid.

--- a/src/build-from-oxlint-config/types.ts
+++ b/src/build-from-oxlint-config/types.ts
@@ -1,5 +1,7 @@
 import type { Linter } from 'eslint';
 
+export type OxlintExtendsConfigs = string[];
+
 export type OxlintConfigPlugins = string[];
 
 export type OxlintConfigCategories = Record<string, unknown>;
@@ -18,6 +20,7 @@ export type OxlintConfigOverride = {
 
 export type OxlintConfig = {
   [key: string]: unknown;
+  extends?: OxlintExtendsConfigs;
   plugins?: OxlintConfigPlugins;
   categories?: OxlintConfigCategories;
   rules?: OxlintConfigRules;

--- a/src/build-from-oxlint-config/types.ts
+++ b/src/build-from-oxlint-config/types.ts
@@ -1,6 +1,6 @@
 import type { Linter } from 'eslint';
 
-export type OxlintExtendsConfigs = string[];
+export type OxlintConfigExtends = string[];
 
 export type OxlintConfigPlugins = string[];
 
@@ -20,9 +20,15 @@ export type OxlintConfigOverride = {
 
 export type OxlintConfig = {
   [key: string]: unknown;
-  extends?: OxlintExtendsConfigs;
+  extends?: OxlintConfigExtends;
   plugins?: OxlintConfigPlugins;
   categories?: OxlintConfigCategories;
   rules?: OxlintConfigRules;
   ignorePatterns?: OxlintConfigIgnorePatterns;
+
+  // extra properties only used by  `eslint-plugin-oxlint`
+  __misc?: {
+    // absolute path to the config file
+    filePath: string;
+  };
 };

--- a/src/build-from-oxlint-config/utilities.ts
+++ b/src/build-from-oxlint-config/utilities.ts
@@ -1,5 +1,42 @@
+import fs from 'node:fs';
+import JSONCParser from 'jsonc-parser';
+import { OxlintConfig } from './types.js';
+
 /**
  * Detects it the value is an object
  */
 export const isObject = (value: unknown): boolean =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
+
+/**
+ * tries to read the oxlint config file and returning its JSON content.
+ * if the file is not found or could not be parsed, undefined is returned.
+ * And an error message will be emitted to `console.error`
+ */
+export const getConfigContent = (
+  oxlintConfigFile: string
+): OxlintConfig | undefined => {
+  try {
+    const content = fs.readFileSync(oxlintConfigFile, 'utf8');
+
+    try {
+      const configContent = JSONCParser.parse(content);
+
+      if (!isObject(configContent)) {
+        throw new TypeError('not an valid config file');
+      }
+
+      return configContent;
+    } catch {
+      console.error(
+        `eslint-plugin-oxlint: could not parse oxlint config file: ${oxlintConfigFile}`
+      );
+      return undefined;
+    }
+  } catch {
+    console.error(
+      `eslint-plugin-oxlint: could not find oxlint config file: ${oxlintConfigFile}`
+    );
+    return undefined;
+  }
+};


### PR DESCRIPTION
## Description

This PR introduces an initial implementation to support the extends property in configuration files and follow the full chain of extended files.

Currently, it handles merging of only the following fields:
- `rules`
- `plugins`
- `overrides`

These are the only fields currently supported by oxlint, and it doesn’t appear necessary to support others at this stage.

Fixes #386 