### PR TITLE
chore(npm): do not publish test files

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
   },
   "files": [
     "dist",
-    "src"
+    "src",
+    "!**/*.spec.ts",
+    "!**/*.snap"
   ],
   "author": "Dunqing <dengqing0821@gmail.com>",
   "homepage": "https://github.com/oxc-project/eslint-plugin-oxlint",


### PR DESCRIPTION
Running `npm pack` on main:

```
npm notice package size: 44.6 kB
npm notice unpacked size: 249.3 kB
```

After:
```
npm notice package size: 35.5 kB
npm notice unpacked size: 194.2 kB
```