### PR TITLE
chore: manage lint ignores in oxlintrc

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -6,5 +6,6 @@
   },
   "rules": {
     "@typescript-eslint/no-unsafe-type-assertion": "off" // FIX: ignore them inline or fix them
-  }
+  },
+  "ignorePatterns": ["dist/"]
 }

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -4,9 +4,6 @@ import eslint from '@eslint/js';
 import tseslint from 'typescript-eslint';
 
 export default [
-  {
-    ignores: ['dist/'],
-  },
   eslint.configs.recommended,
   unicorn.configs['flat/recommended'],
   ...tseslint.configs.recommended,


### PR DESCRIPTION
By #564, it sets `ignorePatterns` in `oxlintrc`, meaning it now also applies to ESLint.
