### PR TITLE
prefer-mock-return-shorthand compatible vitest rule

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -74,6 +74,7 @@ export const viteTestCompatibleRules = [
   'prefer-hooks-on-top',
   'prefer-lowercase-title',
   'prefer-mock-promise-shorthand',
+  'prefer-mock-return-shorthand',
   'prefer-spy-on',
   'prefer-strict-equal',
   'prefer-to-be',


### PR DESCRIPTION
Depends on: https://github.com/oxc-project/oxc/pull/18002