### PR TITLE
chore: migrate oxlint CLI type flags to config options

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -8,5 +8,9 @@
     "@typescript-eslint/no-unsafe-type-assertion": "off", // FIX: ignore them inline or fix them
     "no-shadow": "off" // FIX: ignore them inline or fix them
   },
-  "ignorePatterns": ["dist/"]
+  "ignorePatterns": ["dist/"],
+  "options": {
+    "typeAware": true,
+    "typeCheck": true
+  }
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "prepare": "husky",
     "generate": "node --import @oxc-node/core/register ./scripts/generate-vitest-rules.ts && node --import @oxc-node/core/register ./scripts/generate.ts && pnpm format",
     "build": "vite build",
-    "lint": "npx oxlint --type-aware --type-check && npx eslint",
+    "lint": "npx oxlint && npx eslint",
     "format": "npx oxfmt",
     "test": "vitest --reporter=verbose"
   },


### PR DESCRIPTION
## Summary
- upgrade oxlint to latest
- migrate `--type-aware` / `--type-check` from CLI usage to `oxlint` config `options`
- refresh lockfiles/config as needed

## Context
Aligned with the oxlint options migration introduced in oxc-project/oxc#19923.