### PR TITLE
fix: ignore @typescript-eslint/consistent-type-imports for vue, astro, and svelte files

### DIFF
--- a/src/build-from-oxlint-config/index.ts
+++ b/src/build-from-oxlint-config/index.ts
@@ -13,7 +13,7 @@ import {
 import { defaultPlugins, readPluginsFromConfig } from './plugins.js';
 import { handleIgnorePatternsScope, readIgnorePatternsFromConfig } from './ignore-patterns.js';
 import { handleOverridesScope, readOverridesFromConfig } from './overrides.js';
-import { splitDisabledRulesForVueAndSvelteFiles } from '../config-helper.js';
+import { splitDisabledRulesForVueAstroAndSvelteFiles } from '../config-helper.js';
 import {
   handleExtendsScope,
   readExtendsConfigsFromConfig,
@@ -68,7 +68,9 @@ export const buildFromOxlintConfig = (
   };
 
   const overrides = readOverridesFromConfig(config);
-  const configs = splitDisabledRulesForVueAndSvelteFiles(baseConfig) as EslintPluginOxlintConfig[];
+  const configs = splitDisabledRulesForVueAstroAndSvelteFiles(
+    baseConfig
+  ) as EslintPluginOxlintConfig[];
 
   if (overrides !== undefined) {
     handleOverridesScope(overrides, configs, categories, options);

--- a/src/config-helper.spec.ts
+++ b/src/config-helper.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vite-plus/test';
 import {
   overrideDisabledRulesForVueAndSvelteFiles,
-  splitDisabledRulesForVueAndSvelteFiles,
+  splitDisabledRulesForVueAstroAndSvelteFiles,
 } from './config-helper.js';
 
 describe('overrideDisabledRulesForVueAndSvelteFiles', () => {
@@ -38,7 +38,7 @@ describe('overrideDisabledRulesForVueAndSvelteFiles', () => {
       overrides: [
         {
           files: ['*.*'],
-          excludedFiles: ['*.vue', '*.svelte'],
+          excludedFiles: ['*.vue', '*.svelte', '*.astro'],
           rules: {
             'no-unused-vars': 'off',
           },
@@ -56,7 +56,7 @@ describe('splitDisabledRulesForVueAndSvelteFiles', () => {
       },
     } as const;
 
-    const newConfigs = splitDisabledRulesForVueAndSvelteFiles(config);
+    const newConfigs = splitDisabledRulesForVueAstroAndSvelteFiles(config);
 
     expect(newConfigs).toStrictEqual([
       {
@@ -67,7 +67,7 @@ describe('splitDisabledRulesForVueAndSvelteFiles', () => {
     ]);
   });
 
-  it('creates a second config when no matching rule detected', () => {
+  it('creates a second config when matching rule detected', () => {
     const config = {
       rules: {
         'no-magic-numbers': 'off',
@@ -75,7 +75,7 @@ describe('splitDisabledRulesForVueAndSvelteFiles', () => {
       },
     } as const;
 
-    const newConfigs = splitDisabledRulesForVueAndSvelteFiles(config);
+    const newConfigs = splitDisabledRulesForVueAstroAndSvelteFiles(config);
 
     expect(newConfigs).toStrictEqual([
       {
@@ -84,8 +84,8 @@ describe('splitDisabledRulesForVueAndSvelteFiles', () => {
         },
       },
       {
-        name: 'oxlint/vue-svelte-exceptions',
-        ignores: ['**/*.vue', '**/*.svelte'],
+        name: 'oxlint/vue-svelte-astro-exceptions',
+        ignores: ['**/*.vue', '**/*.svelte', '**/*.astro'],
         rules: {
           'no-unused-vars': 'off',
         },

--- a/src/config-helper.ts
+++ b/src/config-helper.ts
@@ -1,4 +1,4 @@
-import { rulesDisabledForVueAndSvelteFiles } from './constants.js';
+import { rulesDisabledForVueAstroAndSvelteFiles } from './constants.js';
 
 // Some type helpers for better type inference
 type LegacyConfig = {
@@ -19,7 +19,7 @@ type FlatConfig = {
 // for eslint legacy configuration
 export const overrideDisabledRulesForVueAndSvelteFiles = <C extends LegacyConfig>(config: C): C => {
   const foundRules = Object.keys(config.rules!).filter((rule) =>
-    rulesDisabledForVueAndSvelteFiles.includes(rule)
+    rulesDisabledForVueAstroAndSvelteFiles.includes(rule)
   );
 
   if (foundRules.length === 0) {
@@ -32,7 +32,7 @@ export const overrideDisabledRulesForVueAndSvelteFiles = <C extends LegacyConfig
     {
       // classic configs use glob syntax
       files: ['*.*'],
-      excludedFiles: ['*.vue', '*.svelte'],
+      excludedFiles: ['*.vue', '*.svelte', '*.astro'],
       rules: {},
     },
   ];
@@ -48,11 +48,11 @@ export const overrideDisabledRulesForVueAndSvelteFiles = <C extends LegacyConfig
 export type SplittedFlatConfig<C extends FlatConfig> = [C] | [C, FlatConfig];
 
 // for eslint flat configuration
-export const splitDisabledRulesForVueAndSvelteFiles = <C extends FlatConfig>(
+export const splitDisabledRulesForVueAstroAndSvelteFiles = <C extends FlatConfig>(
   config: C
 ): SplittedFlatConfig<C> => {
   const foundRules = Object.keys(config.rules!).filter((rule) =>
-    rulesDisabledForVueAndSvelteFiles.includes(rule)
+    rulesDisabledForVueAstroAndSvelteFiles.includes(rule)
   );
 
   if (foundRules.length === 0) {
@@ -63,8 +63,8 @@ export const splitDisabledRulesForVueAndSvelteFiles = <C extends FlatConfig>(
 
   const newConfig: FlatConfig = {
     // flat configs use minimatch syntax
-    name: 'oxlint/vue-svelte-exceptions',
-    ignores: ['**/*.vue', '**/*.svelte'],
+    name: 'oxlint/vue-svelte-astro-exceptions',
+    ignores: ['**/*.vue', '**/*.svelte', '**/*.astro'],
     rules: {},
   };
 
@@ -76,13 +76,15 @@ export const splitDisabledRulesForVueAndSvelteFiles = <C extends FlatConfig>(
   return [oldConfig, newConfig];
 };
 
-export const splitDisabledRulesForVueAndSvelteFilesDeep = <T extends Record<string, FlatConfig>>(
+export const splitDisabledRulesForVueAstroAndSvelteFilesDeep = <
+  T extends Record<string, FlatConfig>,
+>(
   config: T
 ): { [K in keyof T]: SplittedFlatConfig<T[K]> } => {
   const result = {} as { [K in keyof T]: SplittedFlatConfig<T[K]> };
 
   for (const name in config) {
-    result[name] = splitDisabledRulesForVueAndSvelteFiles(config[name]);
+    result[name] = splitDisabledRulesForVueAstroAndSvelteFiles(config[name]);
   }
 
   return result;

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -4,8 +4,8 @@ import configByScope from './generated/configs-by-scope.js';
 import configByCategory from './generated/configs-by-category.js';
 import {
   overrideDisabledRulesForVueAndSvelteFiles,
-  splitDisabledRulesForVueAndSvelteFiles,
-  splitDisabledRulesForVueAndSvelteFilesDeep,
+  splitDisabledRulesForVueAstroAndSvelteFiles,
+  splitDisabledRulesForVueAstroAndSvelteFilesDeep,
 } from './config-helper.js';
 
 type UnionToIntersection<U> = (U extends unknown ? (x: U) => void : never) extends (
@@ -38,14 +38,14 @@ export default {
     plugins: ['oxlint'],
     rules: allRules,
   }),
-  'flat/all': splitDisabledRulesForVueAndSvelteFiles({
+  'flat/all': splitDisabledRulesForVueAstroAndSvelteFiles({
     name: 'oxlint/all',
     rules: allRules,
   }),
-  'flat/recommended': splitDisabledRulesForVueAndSvelteFiles({
+  'flat/recommended': splitDisabledRulesForVueAstroAndSvelteFiles({
     name: 'oxlint/recommended',
     rules: ruleMapsByCategory.correctnessRules,
   }),
-  ...splitDisabledRulesForVueAndSvelteFilesDeep(configByScope),
-  ...splitDisabledRulesForVueAndSvelteFilesDeep(configByCategory),
+  ...splitDisabledRulesForVueAstroAndSvelteFilesDeep(configByScope),
+  ...splitDisabledRulesForVueAstroAndSvelteFilesDeep(configByCategory),
 } as const;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -47,10 +47,11 @@ export const unicornRulesExtendEslintRules = ['no-negated-condition'];
 // Since oxlint supports these rules under react/*, we need to remap them.
 export const reactHookRulesInsideReactScope = ['rules-of-hooks', 'exhaustive-deps'];
 
-// These rules are disabled for vue and svelte files
+// These rules are disabled for vue, astro, and svelte files
 // because oxlint can not parse currently the HTML
-export const rulesDisabledForVueAndSvelteFiles = [
+export const rulesDisabledForVueAstroAndSvelteFiles = [
   'no-unused-vars',
   '@typescript-eslint/no-unused-vars',
+  '@typescript-eslint/consistent-type-imports',
   'react-hooks/rules-of-hooks', // disabled because its react
 ];


### PR DESCRIPTION
upstream PR: https://github.com/oxc-project/oxc/pull/21415