### PR TITLE
chore: use HTTPS repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "Dunqing <dengqing0821@gmail.com>",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/oxc-project/eslint-plugin-oxlint.git"
+    "url": "git+https://github.com/oxc-project/eslint-plugin-oxlint"
   },
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "Dunqing <dengqing0821@gmail.com>",
   "repository": {
     "type": "git",
-    "url": "git@github.com:oxc-project/eslint-plugin-oxlint.git"
+    "url": "git+https://github.com/oxc-project/eslint-plugin-oxlint.git"
   },
   "files": [
     "dist",


### PR DESCRIPTION
Updates the package repository metadata to use the public HTTPS GitHub URL instead of an SSH-style URL.

The package is public, so the HTTPS URL is friendlier for npm metadata consumers and environments without SSH GitHub access. Runtime code, dependencies, license, homepage, bugs URL, and package contents are unchanged.