### PR TITLE
ci: change release assignee from Sysix to Boshen

### DIFF
--- a/.github/workflows/bump_oxlint.yml
+++ b/.github/workflows/bump_oxlint.yml
@@ -59,5 +59,5 @@ jobs:
           branch: release
           branch-suffix: timestamp
           title: 'release: v${{ inputs.version }}'
-          assignees: camc314, Sysix
+          assignees: camc314, Boshen
           base: main


### PR DESCRIPTION
Change the release PR assignee from `Sysix` to `Boshen` in the `Bump oxlint` workflow.